### PR TITLE
Remove multilanguage

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -1,22 +1,12 @@
 baseurl = "/"
 languageCode = "fr"
 defaultContentLanguage = "fr"
-defaultContentLanguageInSubdir = true
 title = "Sogilis blog Site"
 theme = "sogilis"
 enableEmoji = true
 debug = true
 paginate = 999
 disqusShortname = "sogilisblog"
-
-[languages.en]
-  languageName = "English"
-
-  [languages.en.params]
-    twitter = "https://twitter.com/Sogilis?lang=en"
-    linkedin = "https://www.linkedin.com/company/sogilis/"
-    dateFormat = "January 2 2006"
-
 
 [languages.fr]
   languageName = "Français"


### PR DESCRIPTION
Multilanguage implies many issues, like:
- links in header and footer are differents (sogilis.com vs sogilis.fr)
- showing all articles regardless current languages requires to do some tricky things
- then links of english article will switch to english language (even if current language is french)
- Netlify CMS does not support yet multilanguage content (see https://github.com/netlify/netlify-cms/issues/716)