### PR TITLE
fix: remove italic with all links

### DIFF
--- a/site/content/posts/2016-07-13-user-testing-decision-making.md
+++ b/site/content/posts/2016-07-13-user-testing-decision-making.md
@@ -12,7 +12,7 @@ tags:
 ---
 ## How we iterated on feedback
 
-_[After running each workshop](http://sogilis.com/blog/designing-hexo-mobile-app-design-sprints/)_, we got a lot of ideas down on paper. It’s good to have ideas but you can’t test and build ‘em all. You have to make decisions. In the previous article, we talked about how we agreed on one or a few solutions and resisted the temptation to introduce any new ideas. Well, we did. Most of the time. But stabilising a design approval can be tricky. In the final two parts of the article series, we’ll talk about our decision-making process and how feedback can be both extremely valuable and hard to manage.
+[After running each workshop](http://sogilis.com/blog/designing-hexo-mobile-app-design-sprints/), we got a lot of ideas down on paper. It’s good to have ideas but you can’t test and build ‘em all. You have to make decisions. In the previous article, we talked about how we agreed on one or a few solutions and resisted the temptation to introduce any new ideas. Well, we did. Most of the time. But stabilising a design approval can be tricky. In the final two parts of the article series, we’ll talk about our decision-making process and how feedback can be both extremely valuable and hard to manage.
 
  ![testing](/img/2016/07/testing.gif)
 
@@ -26,7 +26,7 @@ For designing the Hexo+ mobile app our team decided to prototype early and repla
 
 **IOS and Android guidelines**
 
-We respected _[Android](https://material.google.com/#)_ and _[IOS](https://developer.apple.com/ios/human-interface-guidelines/)_ standards and based our UI on these guidelines. We created two different storyboards, one for each OS. We tried to build a look-and-feel as consistent as possible across both platforms.
+We respected [Android](https://material.google.com/#) and [IOS](https://developer.apple.com/ios/human-interface-guidelines/) standards and based our UI on these guidelines. We created two different storyboards, one for each OS. We tried to build a look-and-feel as consistent as possible across both platforms.
 
 ![pfc-android-1](/img/2016/07/pfc-android-1.jpg)
 

--- a/site/content/posts/2016-07-26-hexo-stabilise-feedback.md
+++ b/site/content/posts/2016-07-26-hexo-stabilise-feedback.md
@@ -10,7 +10,7 @@ tags:
   - mobile app
 
 ---
-A few weeks after interviewing _[one of our expert user](https://www.facebook.com/xvdelerue/)_, we questioned that _[decision](http://sogilis.com/blog/user-testing-decision-making/)_ again. ‘The app is never really adapted to the field, there’s always a tree, some obstacle.’ When you are in the middle of nowhere with your drone, you probably want to understand what it’s going to do, what footage you’ll get, and where you stand in the landscape. You need to have a mental model of what’s gonna happen and create an imaginary link between you and your drone. This matter soon became our first concern. It addressed critical things such as anticipation, risk reduction and human error prevention.
+A few weeks after interviewing [one of our expert user](https://www.facebook.com/xvdelerue/), we questioned that [decision](http://sogilis.com/blog/user-testing-decision-making/) again. ‘The app is never really adapted to the field, there’s always a tree, some obstacle.’ When you are in the middle of nowhere with your drone, you probably want to understand what it’s going to do, what footage you’ll get, and where you stand in the landscape. You need to have a mental model of what’s gonna happen and create an imaginary link between you and your drone. This matter soon became our first concern. It addressed critical things such as anticipation, risk reduction and human error prevention.
 
 ![xavproto_1-min](/img/2016/07/xavproto_1-min.jpg)
 

--- a/site/content/posts/2016-07-28-on-recrute.md
+++ b/site/content/posts/2016-07-28-on-recrute.md
@@ -19,11 +19,11 @@ tags:
 
 **On a le droit de se tromper.** Plutôt que de se résigner, on va chercher à analyser ensemble comment résoudre les problèmes et essayer de s’améliorer. On préfère sortir de notre zone de confort et se poser de nouvelles questions, plutôt que de rester dans la routine. 
 
-**Si tu veux en savoir plus sur Sogilis, nous t’invitons à lire _[notre histoire sur le blog](http://sogilis.com/blog/sogilis-histoire/)_.** 
+**Si tu veux en savoir plus sur Sogilis, nous t’invitons à lire [notre histoire sur le blog](http://sogilis.com/blog/sogilis-histoire/).** 
 
 **En pratique ? On fait de tout : du web, du back-end, de l’embarqué, du mobile.**
 
-À notre actif, nous avons développé un logiciel embarqué critique sur un gros avion de ligne, le soft embarqué du drone de loisir _[Hexo+](https://hexoplus.com/)_, des applications mobiles Android/iOS, une solution d’implantologie dentaire, un logiciel pour gérer un réseau d’imprimantes 3D. 
+À notre actif, nous avons développé un logiciel embarqué critique sur un gros avion de ligne, le soft embarqué du drone de loisir [Hexo+](https://hexoplus.com/), des applications mobiles Android/iOS, une solution d’implantologie dentaire, un logiciel pour gérer un réseau d’imprimantes 3D. 
 
 À côté de nos clients, **on a aussi une activité de R&D**. Nous sommes en train de développer un autopilote certifié pour drones, afin de rendre ces derniers aussi sûrs que les avions. 
 

--- a/site/content/posts/2016-08-16-objets-insolites-sogilis-1.md
+++ b/site/content/posts/2016-08-16-objets-insolites-sogilis-1.md
@@ -20,7 +20,7 @@ Un jour, il a fallu créer un indicateur d’occupation, autrement dit un calend
 
 ## 2. Le plan de domination du monde
 
-Vous connaissez le _[Google Master Plan](https://www.flickr.com/photos/jurvetson/21470089/sizes/o/)_ ? Et bien nous avons aussi le notre. C’est surtout un moyen pour rêver et imaginer… ce qui peut se révéler réalisable !
+Vous connaissez le [Google Master Plan](https://www.flickr.com/photos/jurvetson/21470089/sizes/o/) ? Et bien nous avons aussi le notre. C’est surtout un moyen pour rêver et imaginer… ce qui peut se révéler réalisable !
 
 ![](https://67.media.tumblr.com/28e8d307e5e68720089afdbf4c9bf75e/tumblr_inline_nv6ov1L66X1t2p7ex_540.jpg)
 

--- a/site/content/posts/2016-09-06-srp-single-responsibility-principle-code.md
+++ b/site/content/posts/2016-09-06-srp-single-responsibility-principle-code.md
@@ -10,7 +10,7 @@ tags:
   - SRP
 
 ---
-Le principe de responsabilité unique (**Single Responsibility Principle** ou SRP) fait partie d'un ensemble de 5 principes de la programmation orientée objet : _[SOLID](https://fr.wikipedia.org/wiki/SOLID_(informatique))_.
+Le principe de responsabilité unique (**Single Responsibility Principle** ou SRP) fait partie d'un ensemble de 5 principes de la programmation orientée objet : [SOLID](https://fr.wikipedia.org/wiki/SOLID_(informatique)).
 
 - **S** : Single Responsibility Principle
 - **O** : Open/Closed Principle
@@ -73,7 +73,7 @@ Il y a donc quelque chose qui cloche avec cette interprétation naïve.
 
 ## Que dit Internet ?
 
-Une recherche rapide sur _[Grogeule](http://www.grogueule.fr)_ nous donne les éléments suivants :
+Une recherche rapide sur [Grogeule](http://www.grogueule.fr) nous donne les éléments suivants :
 
 * _Every class should have a single responsibility, and that responsibility should be entirely encapsulated by the class_
   Le niveau d'abstraction est la **classe**. **De plus, on va ici plus loin que notre interprétation naïve : il y a **bijection** entre classe et responsabilité.
@@ -137,7 +137,7 @@ Robert est clair sur ce point : **c'est presque toujours à** **éviter** puisqu
 
 - Difficulté : **comment savoir ce qui va changer dans le futur ?** On peut imaginer beaucoup de choses, mais qu'est-ce qui sera vraiment appliqué ? Il y a toujours le risque d'anticiper des évolutions qui n'arriverons jamais... L'article de Robert ne nous aide pas vraiment (voire pas du tout).
 
-- De plus, cette anticipation est en contradiction avec le principe _[YAGNI](https://fr.wikipedia.org/wiki/YAGNI)_ ou _[KISS](https://fr.wikipedia.org/wiki/Principe_KISS)_ !
+- De plus, cette anticipation est en contradiction avec le principe [YAGNI](https://fr.wikipedia.org/wiki/YAGNI) ou [KISS](https://fr.wikipedia.org/wiki/Principe_KISS) !
 
 Personnellement, je fais une étude de risque rapide dont voici les détails. Sur une classe donnée, pour chaque évolution que je peux imaginer (généralement entre 2 et 5), je calcule le coefficient suivant :
 
@@ -190,7 +190,7 @@ Il ne faut pas oublier que ce n'est qu'un principe parmi d'autres. Et cette sép
 
 Voici d’autres méthodes ou pratiques, complémentaires ou non, qui donnent d’autres orientations pour découper le code :
 
-- _[Composed Method](http://c2.com/ppr/wiki/WikiPagesAboutRefactoring/ComposedMethod.html)_
-- _[DDD](https://en.wikipedia.org/wiki/Domain-driven_design)_
+- [Composed Method](http://c2.com/ppr/wiki/WikiPagesAboutRefactoring/ComposedMethod.html)
+- [DDD](https://en.wikipedia.org/wiki/Domain-driven_design)
 
-_[Jean-Baptiste](https://fr.linkedin.com/in/jean-baptiste-mille-0383b81/fr)_
+[Jean-Baptiste](https://fr.linkedin.com/in/jean-baptiste-mille-0383b81/fr)

--- a/site/content/posts/2016-09-27-mise-place-livret-accueil.md
+++ b/site/content/posts/2016-09-27-mise-place-livret-accueil.md
@@ -18,7 +18,7 @@ tags:
 
 L’arrivée au sein d’une nouvelle entreprise est significative de changements : on doit retenir de nombreuses informations. Alors par où commencer ? **Le livret nous a semblé être un outil “facilitateur” lors de l’intégration.** Attention, il ne doit en rien changer le partage d’informations à l’oral, mais doit être complémentaire. C’est un repère écrit, ce qui signifie que les informations sont toujours disponibles.
 
-C’est d’autant plus important qu’au sein de Sogilis, _[nous n’avons pas de manager](https://blogbewhy.wordpress.com/2015/11/16/3-raisons-qui-font-de-lentreprise-liberee-un-veritable-avantage-concurrentiel/)_ : en effet, chacun est responsable et autonome. Quand un nouveau membre arrive dans l’équipe, il a donc beaucoup de questions.
+C’est d’autant plus important qu’au sein de Sogilis, [nous n’avons pas de manager](https://blogbewhy.wordpress.com/2015/11/16/3-raisons-qui-font-de-lentreprise-liberee-un-veritable-avantage-concurrentiel/) : en effet, chacun est responsable et autonome. Quand un nouveau membre arrive dans l’équipe, il a donc beaucoup de questions.
 
 ## Avoir toutes les informations importantes… en un livret court
 
@@ -50,7 +50,7 @@ Finalement, **être précis, drôle et informatif à la fois**.
 
 **Vie interne** : toutes les informations pratiques.
   
-- les rendez-vous internes : _[rétrospective mensuelle](http://sogilis.com/blog/retrospective-mensuelle/)_, entretien individuel, update financier, Sogiday, etc.
+- les rendez-vous internes : [rétrospective mensuelle](http://sogilis.com/blog/retrospective-mensuelle/), entretien individuel, update financier, Sogiday, etc.
   
 - l’organisation : télétravail, mutuelle, etc.
   
@@ -58,7 +58,7 @@ Finalement, **être précis, drôle et informatif à la fois**.
   
 - les budgets par personne (participation à des conférences, ordinateur, déplacements…)
   
-- l’essentiel : _[le tournoi Sogipong](https://twitter.com/sogilis/status/586215615117062144)_, les activités diverses, le café, etc.
+- l’essentiel : [le tournoi Sogipong](https://twitter.com/sogilis/status/586215615117062144), les activités diverses, le café, etc.
 
 **Mise en place d’un projet** : les développeurs choisissent les projets sur lesquels ils souhaitent participer. Oui mais, en détail, avoir un rappel du fonctionnement, ça peut toujours aider quand on est nouveau. D’autant plus sachant que c’est l’équipe fait elle-même les avant-ventes.
 
@@ -84,7 +84,7 @@ _[Myriam][1]_
 
 **A lire également :**
 
-- _[Mon intégration au sein de Sogilis : bilan après un mois](http://sogilis.com/blog/integration-sogilis-bilan/)_
-- _[Victor se lance dans l'entrepreneuriat](http://sogilis.com/blog/victor-entrepreneuriat/)_
+- [Mon intégration au sein de Sogilis : bilan après un mois](http://sogilis.com/blog/integration-sogilis-bilan/)
+- [Victor se lance dans l'entrepreneuriat](http://sogilis.com/blog/victor-entrepreneuriat/)
 
 [1]: https://fr.linkedin.com/in/myriammenneteau

--- a/site/content/posts/2017-02-07-inline-comments-pull-requests.md
+++ b/site/content/posts/2017-02-07-inline-comments-pull-requests.md
@@ -351,4 +351,4 @@ Notice that rules are now a bit more complicated for removed lines. In particula
 
 As it happens, defining the algorithmic rules for updating inline comments was not so trivial. Cases like rebase long baffled us and we were not sure we understood how it impacted inline comments. Actually, it took us a few iterations to set things straight. Yet, once we found the gist of it, it looked surprisingly natural: we just describe the space of each changeset with some coordinates, identify how those spaces connect to each other, and apply rules to translate coordinates between connected spaces.
 
-_[Simon Denier](https://twitter.com/simondenier)_
+[Simon Denier](https://twitter.com/simondenier)


### PR DESCRIPTION
This renders bad links which contains parenthesis.

Exemple with:
	`_[SOLID](https://fr.wikipedia.org/wiki/SOLID_(informatique))_`
We get this in rendereed page:
	`[SOLID](https://fr.wikipedia.org/wiki/SOLID(informatique))_`
Instead of:
	`SOLID`

This fixes #87