### PR TITLE
Fix #146 : after the upgrade of the CMS template, we could again develop with Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,23 @@
-node_modules/
-dist/
-export/
+# !!!!!!!!!!!!!!!!!! Warning !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# .dockerignore is a simlink of .gitiignore
+# THEREFORE:
+# THE FOLLOWING SYNTAX SHOULD BE COMPATIBLE BETWEEN .DOCKERIGNORE AND .GITIIGNORE
+# See https://zzz.buzz/2018/05/23/differences-of-rules-between-gitignore-and-dockerignore/
+
+/node_modules/
+/dist/
+/export/
 /npm-debug.log
-yarn-error.log
+/yarn-error.log
 
 # You can download manually Hugo binaries here
-bin/
+/bin/
 
 # Generated resources (like css from scss)
-site/resources/_gen
+/site/resources/_gen
 
 # Idea IntelliJ
-.idea/
+/.idea/
 
 # Only yarn is advise.
-package-lock.json
+/package-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,20 @@
-# Actually (01/25/2020), the node version used on netlify is the following.
-# (just for information)
-FROM node:10-alpine
-
-ENV HUGO_VERSION='0.63.1'
-ENV HUGO_NAME="hugo_extended_${HUGO_VERSION}_Linux-64bit"
-ENV HUGO_BASE_URL="https://github.com/gohugoio/hugo/releases/download"
-ENV HUGO_URL="${HUGO_BASE_URL}/v${HUGO_VERSION}/${HUGO_NAME}.tar.gz"
+FROM node:12-alpine
 
 WORKDIR /blog
 
 # libxxx are required by extended edition of Hugo
 RUN apk add --no-cache \
-    asciidoctor \
-    wget \
     libc6-compat \
     libstdc++
 
-RUN mkdir ./bin/ && \
-    wget -qO- "${HUGO_URL}" | tar xvz -C ./bin/ && \
-    mv ./bin/hugo bin/hugo.linux && \
-    chmod a+x ./bin/hugo.linux && \
-    ln /blog/bin/hugo.linux /usr/local/bin/hugo
-
-COPY site site
-COPY src src
-COPY .*rc ./
-COPY netlify.toml netlify.toml
-COPY renovate.json renovate.json
-COPY package*.json  ./
-COPY gulpfile.babel.js gulpfile.babel.js
-COPY webpack.conf.js webpack.conf.js
-COPY yarn.lock yarn.lock
+# Some file are ignored
+# See ./.dockerignore
+COPY . ./
 
 RUN yarn install
 
 EXPOSE 3000
-CMD yarn start
+
+# We should add `--host 0.0.0.0` cause of the webpack sever
+# See https://github.com/webpack/webpack-dev-server/issues/547
+CMD yarn run-p "start:webpack --host 0.0.0.0" "start:hugo"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ You will need to install the following software:
         * Disclaimer:
             * On Windows or Mac, installation of Docker could be
                 complicated.
-            * Use more disc space
+            * Use more disc space. It's not a fake affirmation.
+                I've taken fill my free 50Go of disk space simply when I've tested
+                several times to adapt the configuration of the current ./Dockerfile
+                (you could run `docker system prune`).
             * Takes more resources
             * Build the website is incredibly more long especially if you want
                 simply update `node_modules` when package.json is changed.
@@ -101,6 +104,8 @@ Wait a few seconds then, go to [http://localhost:3000](http://localhost:3000).
         * Each time you run `git pull` to update the website, if you don't
             know if this files are changed, you could run this command.
             This command is always very long, even for an upgrade.
+        * Don't forget to run `docker system prune` if you don't want
+            fill your disk.
     * Run:
         ```bash
         make build


### PR DESCRIPTION
Fix #146 : after the upgrade of the CMS template, we could again develop with Docker