### PR TITLE
Fix article content margin with large screen

### DIFF
--- a/site/themes/sogilis/assets/css/article.css
+++ b/site/themes/sogilis/assets/css/article.css
@@ -180,12 +180,6 @@ pre {
   max-width: 100%;
 }
 
-@media (min-width: 1300px) {
-  #articlepage-content {
-    margin: 0 -1rem 0 3.75rem;
-  }
-}
-
 /* Image on the bottom */
 /* ========================================================================== */
 #articlepage-img-bottom {


### PR DESCRIPTION
The margin was on left, and right (with negative value!).

# Header

## Before
<img width="1182" alt="Capture d’écran 2020-09-18 à 09 47 13" src="https://user-images.githubusercontent.com/7377177/93570895-fab69580-f993-11ea-8790-a7c954c8597a.png">

## After
<img width="1182" alt="Capture d’écran 2020-09-18 à 09 47 03" src="https://user-images.githubusercontent.com/7377177/93571170-5da82c80-f994-11ea-8bbb-58038d4e3877.png">


# Footer
## Before
<img width="1182" alt="Capture d’écran 2020-09-18 à 09 44 10" src="https://user-images.githubusercontent.com/7377177/93571018-28034380-f994-11ea-9d8f-775df13ce76e.png">

## After
<img width="1182" alt="Capture d’écran 2020-09-18 à 09 46 02" src="https://user-images.githubusercontent.com/7377177/93570954-0f932900-f994-11ea-971d-44f9b8146ded.png">
