### PR TITLE
Fix article images stretch

### DIFF
--- a/site/themes/sogilis/assets/css/article.css
+++ b/site/themes/sogilis/assets/css/article.css
@@ -149,9 +149,13 @@ pre {
   margin-left: -2.25rem;
 }
 
+#articlepage-header-img {
+  width: 100%
+}
+
 @media (min-width: 992px) {
   /* On the left */
-  #articlepage-header-img {
+  #articlepage-header-img-container {
     max-width: 60%;
   }
   /* On the right */
@@ -167,7 +171,7 @@ pre {
   #articlepage-header-title-h1 {
     margin-top: 3rem;
   }
-  #articlepage-header-img {
+  #articlepage-header-img-container {
     max-width: 100%;
   }
 }

--- a/site/themes/sogilis/assets/css/article.css
+++ b/site/themes/sogilis/assets/css/article.css
@@ -80,6 +80,7 @@ blockquote,
 pre,
 .articlepage-img {
   box-shadow: 0 0 1rem 0.2rem rgba(0, 0, 0, 0.15);
+  width: 100%;
 }
 
 blockquote,
@@ -150,7 +151,7 @@ pre {
 }
 
 #articlepage-header-img {
-  width: 100%
+  width: 100%;
 }
 
 @media (min-width: 992px) {

--- a/site/themes/sogilis/layouts/_default/single.html
+++ b/site/themes/sogilis/layouts/_default/single.html
@@ -3,22 +3,25 @@
 <article id="articlepage">
   <section id="articlepage-header">
     <!-- Illustration -->
-    {{ with .Params.image }}
-    <img
-      id="articlepage-header-img"
-      class="articlepage-img"
-      alt="Illustration de l'article"
-      src="{{ . | relURL }}"
-      />
-      {{ else }}
-      <!-- Default illustration -->
-    <img
-      id="articlepage-header-img"
-      class="articlepage-img"
-      alt="Illustration de l'article"
-      src="{{ "images/blog_preview_default.jpg" | relURL }}"
-      />
-      {{ end }}
+    <span id="articlepage-header-img-container">
+      {{ with .Params.image }}
+      <img
+        id="articlepage-header-img"
+        class="articlepage-img"
+        alt="Illustration de l'article"
+        src="{{ . | relURL }}"
+        />
+        {{ else }}
+        <!-- Default illustration -->
+      <img
+        id="articlepage-header-img"
+        class="articlepage-img"
+        alt="Illustration de l'article"
+        src="{{ "images/blog_preview_default.jpg" | relURL }}"
+        />
+        {{ end }}
+    </span>
+
       <div id="articlepage-header-title">
         <h1 id="articlepage-header-title-h1">{{ .Title }}</h1>
         <p>


### PR DESCRIPTION

# Header
Bug reported only in Safari, with large screen.

## Before
<img width="1182" alt="Capture d’écran 2020-09-18 à 09 53 25" src="https://user-images.githubusercontent.com/7377177/93571528-e1621900-f994-11ea-86c5-9e458e1a0423.png">

## After
<img width="1182" alt="Capture d’écran 2020-09-18 à 09 53 15" src="https://user-images.githubusercontent.com/7377177/93571537-e45d0980-f994-11ea-9e07-2bc3040b6b5a.png">


# Footer (with default article image)
Bug reported only in Safari, Firefox and Chrome, with large screen.
## Before
<img width="1182" alt="Capture d’écran 2020-09-18 à 10 14 29" src="https://user-images.githubusercontent.com/7377177/93573746-d1980400-f997-11ea-90c5-ce5b3034ab10.png">

## After
<img width="1182" alt="Capture d’écran 2020-09-18 à 10 13 46" src="https://user-images.githubusercontent.com/7377177/93573761-d492f480-f997-11ea-8c42-66dcbcb86b38.png">
