### PR TITLE
Reduce margin between figure and corresponding caption

### DIFF
--- a/site/themes/sogilis/assets/css/article.css
+++ b/site/themes/sogilis/assets/css/article.css
@@ -119,6 +119,12 @@ pre {
   }
 }
 
+/* Reduce caption margin in a <figure> (instead of default h4 margin) */
+/* Generated with {{< figure …>}} in .md files */
+figcaption h4 {
+  margin-top: 0.5rem;
+}
+
 /* Section header */
 /* ========================================================================== */
 


### PR DESCRIPTION
Il y a trop de marge sur les légendes d'images. Résultat, on n'a pas l'impression que le sous-titre est rattaché a l'image.

# Avant
<img width="633" alt="Capture d’écran 2020-09-23 à 08 31 50" src="https://user-images.githubusercontent.com/7377177/93975171-480d7b00-fd77-11ea-9839-36dd0998e88f.png">

# Après
<img width="633" alt="Capture d’écran 2020-09-23 à 08 31 59" src="https://user-images.githubusercontent.com/7377177/93975178-49d73e80-fd77-11ea-82aa-f146fbdd78b0.png">

