### PR TITLE
chore: fix slack notification on dead link checker scheduled job

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -24,9 +24,13 @@ jobs:
           CONFIG: hydra-link-checker.json
 
       - name: Send Slack notification
-        uses: act10ns/slack@v1
+        uses: rtCamp/action-slack-notify@master
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        with: 
-          status: ${{ job.status }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_USERNAME: Blog
+          SLACK_ICON_EMOJI: ":bomb:"
+          SLACK_COLOR: "#A30101"
+          SLACK_TITLE: Dead link checker
+          SLACK_MESSAGE: Blog contains dead link(s) :boom:. Please fix this quickly to prevent SEO degradation.
+          SLACK_FOOTER: Scheduled job executed by Github Actions
         if: failure()


### PR DESCRIPTION
# Avant
<img width="666" alt="image" src="https://user-images.githubusercontent.com/7377177/96619570-9fffb900-1306-11eb-92fa-773127a9c0cc.png">

Bug connu (mais non résolu, contrairement au commentaire indiqué) : https://github.com/act10ns/slack/issues/114

# Après

Avec [Slack Notify](https://github.com/marketplace/actions/slack-notify)
<img width="666" alt="image" src="https://user-images.githubusercontent.com/7377177/96619553-9a09d800-1306-11eb-89ac-8eb27da39390.png">
