### PR TITLE
Remove unecessary padding in <blockquote> or <pre>

### DIFF
--- a/site/themes/sogilis/assets/css/article.css
+++ b/site/themes/sogilis/assets/css/article.css
@@ -82,7 +82,7 @@ blockquote,
 pre {
   width: 70%;
   margin: 1.9rem 0 1.9rem 3.75rem;
-  padding: 1.9rem 1.25rem 1.9rem 1.25rem;
+  padding: 0.4rem 1.25rem;
   border: solid 5px transparent;
 }
 


### PR DESCRIPTION
# Before
<img width="758" alt="image" src="https://user-images.githubusercontent.com/7377177/98990670-0d2ff400-252b-11eb-8f5b-4865eea3446c.png">

# After
<img width="758" alt="image" src="https://user-images.githubusercontent.com/7377177/98990654-07d2a980-252b-11eb-9c5a-56c8c4c6a76b.png">



