### PR TITLE
chore: add alt image article param

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ make docker-stop
    author: Author (author@sogilis.com)
    date: 2020-08-20
    image: /img/image-name.jpeg
+   altimage: description and credits of the image
    categories:
      - cat1
      - cat2

--- a/site/content/posts/2020-11-06-vuex-alternative.md
+++ b/site/content/posts/2020-11-06-vuex-alternative.md
@@ -3,6 +3,7 @@ title: Un état centralisé, oui, mais sans Vuex !
 author: Alban et Jean-Baptiste
 date: 2020-11-06
 image: /img/2020-08-31-vuex-alternative/title.jpeg
+altimage: "Vuex article illustration with a big X capital letter"
 categories:
   - DÉVELOPPEMENT
 tags:

--- a/site/static/admin/config.yml
+++ b/site/static/admin/config.yml
@@ -13,6 +13,12 @@ collections: # A list of collections the CMS should be able to edit
       - { label: 'Title', name: 'title', widget: 'string' }
       - { label: 'Publish Date', name: 'date', widget: 'datetime' }
       - { label: 'Intro Blurb', name: 'description', widget: 'text' }
+      - {
+          label: 'Image Alt',
+          name: 'altimage',
+          widget: 'string',
+          required: false,
+        }
       - { label: 'Image', name: 'image', widget: 'image', required: false }
       - { label: 'Body', name: 'body', widget: 'markdown' }
 

--- a/site/themes/sogilis/layouts/_default/single.html
+++ b/site/themes/sogilis/layouts/_default/single.html
@@ -4,15 +4,15 @@
   <section id="articlepage-header">
     <!-- Illustration -->
     <span id="articlepage-header-img-container">
-      {{ with .Params.image }}
-      <img
-        id="articlepage-header-img"
-        class="articlepage-img"
-        alt="Illustration de l'article"
-        src="{{ . | relURL }}"
-        />
-        {{ else }}
+      {{ if (isset .Params "image") }}
+        <img
+          id="articlepage-header-img"
+          class="articlepage-img"
+          alt="{{ .Params.altimage | default "Illustration de l'article" }}"
+          src="{{ .Params.image | relURL }}"
+          />
         <!-- Default illustration -->
+        {{ else }}
       <img
         id="articlepage-header-img"
         class="articlepage-img"


### PR DESCRIPTION
Add the possibility to define an alternative text for article image (and thus give credits to image's authors), adding the custom param `altimage` in article parameters.

This PR is Part of resolution of #194 

I modified the alternative image text for the last article (Vuex), and it gives the following : 

### With altimage set
![with-alt](https://user-images.githubusercontent.com/4182953/99947688-a6a3a500-2d78-11eb-8c53-7c436726a613.png)

### With altimage unset
![without-alt](https://user-images.githubusercontent.com/4182953/99947702-aa372c00-2d78-11eb-9d5e-8e0fd93d0149.png)

### With image unset
![no-image](https://user-images.githubusercontent.com/4182953/99947713-ad321c80-2d78-11eb-8acb-edfeaf81454e.png)
