### PR TITLE
fix indentation config for markdown files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,6 @@ insert_final_newline = true
 # Change these settings to your own preference
 indent_style = space
 indent_size = 2
+
+[*.md]
+indent_size = 4


### PR DESCRIPTION
Default indentation is 2 spaces.
But 2 spaces in code block in articles is too small for lisibility.

# With 2 spaces
<img width="502" alt="Capture d’écran 2020-11-24 à 09 39 34" src="https://user-images.githubusercontent.com/7377177/100069481-1bd6af00-2e39-11eb-865b-c94fff6b2578.png">

# With 4 spaces
<img width="502" alt="Capture d’écran 2020-11-24 à 09 38 49" src="https://user-images.githubusercontent.com/7377177/100069488-1ed19f80-2e39-11eb-97d2-f8a45d194afb.png">
