### PR TITLE
chore: schedule deadlink checker every month

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,7 +1,7 @@
 name: Scheduled
 on:
   schedule:
-    - cron: '0 10 * * MON'
+    - cron: '0 10 1 * *'
 
 jobs:
   # See docs/infra.md for more details


### PR DESCRIPTION
Many false positive appear on each run
 + blog repository does not change often
 = we can check dead link every month, not every week