### PR TITLE
chore: schedule dead link checker every 6 months

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,7 +1,7 @@
 name: Scheduled
 on:
   schedule:
-    - cron: '0 10 1 * *'
+    - cron: '0 10 17 6/6 *'
 
 jobs:
   # See docs/infra.md for more details


### PR DESCRIPTION
Dead link checker raise a lot of false positives (links which are not available temporarily).
More over, SEO impacts is not proven (does the source site is impected or the destination site?).

So, for all these reasons, we decided to decrease the check frequency to every 6 months.